### PR TITLE
Streamline error handling further with ResponseError and Responders

### DIFF
--- a/src/api/todos.rs
+++ b/src/api/todos.rs
@@ -2,26 +2,29 @@ use crate::{models::todo_model::Todo, db::mongodb_repo::{MongoRepo, Error}};
 use actix_web::{
     get,
     post,
+    Responder,
+    http::StatusCode,
     web::{Data, Json, Path},
-    HttpResponse,
+    error::ResponseError,
 };
 
+impl ResponseError for Error {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::ObjectIdError(_) => StatusCode::BAD_REQUEST,
+            Self::MongoDBError(_) | Self::UnexpectedError => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::TaskNotFound => StatusCode::NOT_FOUND,
+        }
+    }
+}
+
 #[get("/todo/{id}")]
-pub async fn get_todo(db: Data<MongoRepo>, path: Path<String>) -> HttpResponse {
-    db.get_todo(&path)
-        .await
-        .map(|todo| HttpResponse::Ok().json(todo))
-        .unwrap_or_else(|err| match err {
-            Error::ObjectIdError(err) => HttpResponse::BadRequest().body(err.to_string()),
-            _ => HttpResponse::InternalServerError().body(err.to_string())
-        })
+pub async fn get_todo(db: Data<MongoRepo>, path: Path<String>) -> Result<impl Responder, Error> {
+    db.get_todo(&path).await.map(Json)
 }
 
 #[post("/todo")]
-pub async fn create_todo(db: Data<MongoRepo>, new_todo: Json<Todo>) -> HttpResponse {
+pub async fn create_todo(db: Data<MongoRepo>, new_todo: Json<Todo>) -> Result<impl Responder, Error> {
     let data = Todo::new(&new_todo.task, new_todo.completed);
-    db.create_todo(data)
-        .await
-        .map(|todo| HttpResponse::Ok().json(todo))
-        .unwrap_or_else(|err| HttpResponse::InternalServerError().body(err.to_string()))
+    db.create_todo(data).await.map(Json)
 }

--- a/src/api/todos.rs
+++ b/src/api/todos.rs
@@ -24,7 +24,6 @@ pub async fn get_todo(db: Data<MongoRepo>, path: Path<String>) -> Result<impl Re
 }
 
 #[post("/todo")]
-pub async fn create_todo(db: Data<MongoRepo>, new_todo: Json<Todo>) -> Result<impl Responder, Error> {
-    let data = Todo::new(&new_todo.task, new_todo.completed);
-    db.create_todo(data).await.map(Json)
+pub async fn create_todo(db: Data<MongoRepo>, todo: Json<Todo>) -> Result<impl Responder, Error> {
+    db.create_todo(todo.into_inner()).await.map(Json)
 }

--- a/src/db/mongodb_repo.rs
+++ b/src/db/mongodb_repo.rs
@@ -30,7 +30,8 @@ impl MongoRepo {
         Ok(MongoRepo { todos })
     }
 
-    pub async fn create_todo(&self, todo: Todo) -> Result<ObjectId, Error> {
+    pub async fn create_todo(&self, mut todo: Todo) -> Result<ObjectId, Error> {
+        todo.id = None;
         self
             .todos
             .insert_one(todo, None)

--- a/src/models/todo_model.rs
+++ b/src/models/todo_model.rs
@@ -8,14 +8,3 @@ pub struct Todo {
     pub task: String,
     pub completed: bool
 }
-
-impl Todo {
-    pub fn new(task: &dyn ToString, completed: bool) -> Self {
-        Todo {
-            id: None,
-            task: task.to_string(),
-            completed
-        }
-    }
-}
-                


### PR DESCRIPTION
- More ideomatic error handling with `actix_web_error::ResponseError`
- Let actix_web build the responses
- Change requesting a non-existing Task into an error to return correct status code
- Streamline api and db functions to have less places for bugs to hide in